### PR TITLE
Fix float-precision while recalculating the processing time

### DIFF
--- a/manpy/simulation/Globals.py
+++ b/manpy/simulation/Globals.py
@@ -516,7 +516,7 @@ def runSimulation(
     trace="No",
     snapshots=False,
     seed=1,
-    env=simpy.Environment(),
+    env=None,
 ):
     G.numberOfReplications = numberOfReplications
     G.trace = trace
@@ -554,7 +554,7 @@ def runSimulation(
             1  # increment the seed so that we get different random numbers in each run.
         )
 
-        G.env = env
+        G.env = env or simpy.Environment()
         # this is where all the simulation object 'live'
 
         G.EntityList = []

--- a/manpy/simulation/Machine.py
+++ b/manpy/simulation/Machine.py
@@ -1161,7 +1161,8 @@ class Machine(CoreObject):
             )
             # recalculate the processing time left tinM
             if self.timeLastOperationStarted >= 0:
-                self.tinM = self.tinM - (self.env.now - self.timeLastOperationStarted)
+                self.tinM = round(self.tinM - (self.env.now - self.timeLastOperationStarted), 4)
+
                 self.timeToEndCurrentOperation = self.env.now + self.tinM
                 if (
                     self.tinM == 0

--- a/manpy/simulation/ScheduledMaintenance.py
+++ b/manpy/simulation/ScheduledMaintenance.py
@@ -60,6 +60,13 @@ class ScheduledMaintenance(ObjectInterruption):
         # the victim can be 'interrupted', 'loaded' or 'emptied' when the maintenance interruption happens
         self.endStatus = endStatus
 
+    def __repr__(self):
+        rep = f"ScheduledMaintenance(victim={self.victim}," \
+              f" start={self.start}," \
+              f" duration={self.duration})"
+        return rep
+
+
     # =======================================================================
     # initialize for every replications
     # =======================================================================

--- a/manpy/simulation/ShiftScheduler.py
+++ b/manpy/simulation/ShiftScheduler.py
@@ -66,6 +66,11 @@ class ShiftScheduler(ObjectInterruption):
         self.rolling = rolling
         self.lastOffShiftDuration = lastOffShiftDuration
 
+    def __repr__(self):
+        rep = f"ShiftScheduler(victim={self.victim}," \
+              f" name={self.name}," \
+              f" shiftPattern={self.shiftPattern})"
+        return rep
     # =======================================================================
     # initialize for every replications
     # =======================================================================


### PR DESCRIPTION
- Fix float-precision while recalculating the processing time left in variable tinM (machine.py)
- Add simpy.Environment() to run_simulation
- Add repr to ShiftScheduler and ScheduleMaintenance

#time 2m